### PR TITLE
Un-break version checking for 1.7.10-2.2.1

### DIFF
--- a/VersionControl.xml
+++ b/VersionControl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties version="1.0">
+    <comment>Version lookup for Modular Systems Credits Pahimar. Format is "Current Version Number|URL to update page"</comment>
+    <entry key="Minecraft 1.7.10">2.2.1|http://minecraft.curseforge.com/mc-mods/68528-modular-systems/files</entry>
+</properties>


### PR DESCRIPTION
Fixes #128, #129

Removing this file remotely crashes all installed copies of ModularSystems. Since you never got around to fixing #110 and #112, this is the least you could do.
